### PR TITLE
fix(ads-filter): Working with mobx

### DIFF
--- a/src/components/Application-Body/JobsAppBody.tsx
+++ b/src/components/Application-Body/JobsAppBody.tsx
@@ -54,7 +54,7 @@ const JobsAppBody: React.FC<JobsAppBodyOwnProps> = (props): JSX.Element => {
                 searchValue={searchValue} 
                 onSearchValueChange={onSearchValueChange}
                 fetchAllAdsAfterPost={jobsStore.loadAdvertisements} />
-            <JobsList ads={jobsStore.advertisements} isFiltered={searchValue !== '' && jobsStore.advertisements.length !== 0}/>
+            <JobsList ads={getFilteredAds()} isFiltered={searchValue !== '' && jobsStore.advertisements.length !== 0}/>
         </div>
     );
 }


### PR DESCRIPTION
A small fix, so filtering will work as it used to.

`getFilterAds()`